### PR TITLE
Morphosyntax: avoid requesting unavailable MWT models

### DIFF
--- a/batchalign/pipelines/morphosyntax/ud.py
+++ b/batchalign/pipelines/morphosyntax/ud.py
@@ -18,6 +18,7 @@ from stanza import DownloadMethod
 from torch import heaviside
 
 from stanza.pipeline.processor import ProcessorVariant, register_processor_variant
+from stanza.resources.common import download_resources_json, load_resources_json, get_language_resources
 
 # the loading bar
 from tqdm import tqdm
@@ -698,13 +699,17 @@ def morphoanalyze(doc: Document, retokenize:bool, status_hook:callable = None, *
     else:
         config["tokenize_postprocessor"] = lambda x:adlist_processor(x)
 
+    download_resources_json()
+    resources = load_resources_json()
+    mwt_exclusion = ["hr", "zh", "zh-hans", "zh-hant", "ja", "ko",
+                     "sl", "sr", "bg", "ru", "et", "hu",
+                     "eu", "el", "he", "af", "ga", "da", "ro"]
+    
     if "zh" in lang:
         lang.pop(lang.index("zh"))
         lang.append("zh-hans")
-
-    elif not any([i in ["hr", "zh", "zh-hans", "zh-hant", "ja", "ko",
-                        "sl", "sr", "bg", "ru", "et", "hu",
-                        "eu", "el", "he", "af", "ga", "da", "ro"] for i in lang]):
+        
+    elif not any(i in mwt_exclusion or "mwt" not in get_language_resources(resources, i) for i in lang):
         if "en" in lang:
             config["processors"]["mwt"] = "gum"
         else:


### PR DESCRIPTION
Hi!

I tried the `morphotag` pipeline on Lithuanian (`lit` or `lt`) and bumped into an instance of Stanza's `UnsupportedProcessorError` that said the following:
> Processor mwt is not known for language lt.  If you have created your own model, please specify the mwt_model_path parameter when creating the pipeline.

Given that it is certainly not just Lithuanian that will trigger this error with no justifiable reason, could I propose checking with Stanza's `resources.json` instead of manually maintaining a list of all languages without a MWT model?

Note: it is not really "instead of" but "alongside" the manually curated list for the purposes of this PR, because I could not safely assume that all of MWT models that had been deemed unnecessary here were actually absent from Stanza's standard repository. Perhaps there had been unrelated reasons to exclude them?