### PR TITLE
Fix Whisper Timestamp Processing in Batchalign Transcribe

### DIFF
--- a/batchalign/models/resolve.py
+++ b/batchalign/models/resolve.py
@@ -11,7 +11,7 @@ resolver = {
         "yue": "PolyU-AngelChanLab/Cantonese-Utterance-Segmentation",
     },
     "whisper": {
-        'eng': ("talkbank/CHATWhisper-en-large-v1", "openai/whisper-large-v2"),
+        'eng': ("talkbank/CHATWhisper-en", "openai/whisper-large-v2"),
         'yue': ("alvanlii/whisper-small-cantonese", "alvanlii/whisper-small-cantonese"),
     }
 }

--- a/batchalign/models/whisper/infer_asr.py
+++ b/batchalign/models/whisper/infer_asr.py
@@ -93,7 +93,7 @@ class WhisperASRModel(object):
                 stride_length_s=3,
                 device=DEVICE,
                 torch_dtype=torch.bfloat16,
-                return_timestamps="word",
+                return_timestamps=True,
             )
         except TypeError:
             self.pipe = pipeline(
@@ -104,7 +104,7 @@ class WhisperASRModel(object):
                 stride_length_s=3,
                 device=DEVICE,
                 torch_dtype=torch.float16,
-                return_timestamps="word",
+                return_timestamps=True,
             )
         L.debug("Done, initalizing processor and config...")
         processor = WhisperProcessor.from_pretrained(base)


### PR DESCRIPTION

## Problem
When using `batchalign transcribe` with the `--whisper` flag, the pipeline fails with a TypeError due to improper handling of None timestamps. This occurs specifically when Whisper fails to predict an ending timestamp, which can happen if audio is cut off mid-word or in certain edge cases.

## Changes
1. Updated the English Whisper model reference from `talkbank/CHATWhisper-en-large-v1` to `talkbank/CHATWhisper-en` in the resolver
2. Modified timestamp return configuration in the Whisper pipeline:
   - Changed `return_timestamps="word"` to `return_timestamps=True` to ensure proper timestamp handling
   - Applied this change in both the primary and fallback pipeline configurations

## Technical Details
- The change from "word" to True for return_timestamps aligns better with the Whisper model's timestamp generation capabilities
- The updated model reference suggests a more stable version for timestamp handling
- These changes address the TypeError that occurred when comparing timestamp values

## Testing
### Manual Testing
Tested with:
```bash
batchalign -vvv transcribe /path/to/input /path/to/output --whisper
```

### Test Results
Comparison with master branch shows:
1. The TypeError we're fixing exists in master
2. Our changes modify how timestamps are handled but don't introduce new failures
3. Existing test failures are present in both branches and need separate attention

### Known Test Issues (Present in Master)
1. `test_preamble_generation`: Header format mismatch
2. `test_recursive_groups`: Group parsing differences
3. `test_wer`: Word Error Rate calculation difference
4. `test_whisper_asr_pipeline`: Timestamp format changes
5. `test_whisper_fa_pipeline`: CUDA memory issues
6. `test_standard_pipeline`: Output structure mismatch

## Impact
- Fixes timestamp comparison errors in the transcription pipeline
- Maintains compatibility with the Whisper model's timestamp generation
- Changes timestamp handling to be more robust
- No new test failures introduced

## Notes
- The test failures present in both branches suggest needed updates to test expectations
- Memory usage optimization for forced alignment should be addressed in a separate PR

## Environment Details
### System Information
- Python: 3.11.11
- PyTorch: 2.6.0+cu124
- CUDA: 12.4
- CUDNN: 9.1.0

### Key Dependencies
- transformers: 4.50.1
- torch: 2.6.0
- torchaudio: 2.6.0
- numpy: 2.2.4
- accelerate: 1.5.2
- batchalign: 0.7.17.post9 (editable install)
- huggingface-hub: 0.29.3
- peft: 0.15.0

### Full Environment
```
Package                  Version      Editable project location
------------------------ ------------ -----------------------------
accelerate               1.5.2
annotated-types          0.7.0
batchalign               0.7.17.post9 /home/varun/repos/batchalign2
blobfile                 3.0.0
certifi                  2025.1.31
cffi                     1.17.1
charset-normalizer       3.4.1
click                    8.1.8
contourpy                1.3.1
coverage                 5.5
cycler                   0.12.1
deprecation              2.1.0
docopt                   0.6.2
emoji                    2.14.1
eyed3                    0.9.7
filelock                 3.18.0
filetype                 1.2.0
fonttools                4.56.0
fsspec                   2025.3.0
hmmlearn                 0.3.0
huggingface-hub          0.29.3
idna                     3.10
imbalanced-learn         0.13.0
imblearn                 0.0
iniconfig                2.1.0
jinja2                   3.1.6
joblib                   1.4.2
kiwisolver               1.4.8
lxml                     5.3.1
markdown-it-py           3.0.2
markupsafe               3.0.2
matplotlib               3.10.1
mdurl                    0.1.2
mpmath                   1.3.0
narwhals                 1.32.0
networkx                 3.4.2
nltk                     3.9.1
num2words                0.5.14
numpy                    2.2.4
nvidia-cublas-cu12       12.4.5.8
nvidia-cuda-cupti-cu12   12.4.127
nvidia-cuda-nvrtc-cu12   12.4.127
nvidia-cuda-runtime-cu12 12.4.127
nvidia-cudnn-cu12        9.1.0.70
nvidia-cufft-cu12        11.2.1.3
nvidia-curand-cu12       10.3.5.147
nvidia-cusolver-cu12     11.6.1.9
nvidia-cusparse-cu12     12.3.1.170
nvidia-cusparselt-cu12   0.6.2
nvidia-nccl-cu12         2.21.5
nvidia-nvjitlink-cu12    12.4.127
nvidia-nvtx-cu12        12.4.127
packaging                24.2
peft                     0.15.0
pillow                   11.1.0
plotly                   6.0.1
pluggy                   1.5.0
praatio                  6.0.1
protobuf                 6.30.1
psutil                   7.0.0
pycountry               24.6.1
pycparser                2.22
pycryptodomex            3.22.0
pydantic                 2.10.6
pydantic-core            2.27.2
pydub                    0.25.1
pyfiglet                 1.0.2
pygments                 2.19.1
pyparsing                3.2.3
pytest                   8.3.5
python-dateutil          2.9.0.post0
pyyaml                   6.0.2
regex                    2024.11.6
requests                 2.32.3
rev-ai                   2.21.0
rich                     13.9.4
rich-click               1.8.8
safetensors              0.5.3
scikit-learn             1.6.1
scipy                    1.15.2
sentencepiece            0.2.0
setuptools               78.1.0
six                      1.17.0
sklearn-compat           0.1.3
soundfile                0.12.1
stanza                   1.10.1
sympy                    1.13.1
threadpoolctl            3.6.0
tiktoken                 0.9.0
tokenizers               0.21.1
toml                     0.10.2
torch                    2.6.0
torchaudio               2.6.0
tqdm                     4.67.1
transformers             4.50.1
triton                   3.2.0
typing-extensions        4.13.0
urllib3                  2.3.0
websocket-client         0.59.0
```

## Error Details
The specific error being fixed:
```python
TypeError: '<=' not supported between instances of 'NoneType' and 'float'
```

This error occurs in the Whisper tokenization process when comparing timestamp values, specifically when a None timestamp is compared with a float value. Our changes ensure proper handling of these cases by modifying how timestamps are returned and processed.