### PR TITLE
Add textgrid file support via lazy loading system

### DIFF
--- a/batchalign/__init__.py
+++ b/batchalign/__init__.py
@@ -29,6 +29,9 @@ def __getattr__(name):
     if name == 'CHATFile':
         from .formats.chat import CHATFile
         return CHATFile
+    if name == 'TextGridFile':
+        from .formats.textgrid import TextGridFile
+        return TextGridFile
     # Add other common engines if needed for dispatch.py
     if name in ['WhisperEngine', 'WhisperFAEngine', 'StanzaEngine', 'RevEngine',
                 'NgramRetraceEngine', 'DisfluencyReplacementEngine', 'WhisperUTREngine',


### PR DESCRIPTION
The TextGridFile class was left out of the lazy loading refactor in 7ece607, so currently you have to manually import to python via `from batchalign.formats.textgrid import TextGridFile`. Just a quick fix to re-add it alongside the CHATFile format.

Now, `print(ba.TextGridFile)` returns `<class 'batchalign.formats.textgrid.file.TextGridFile'>` instead of an Attribute error.